### PR TITLE
Allow data.frame input to load_[mix/source/discr]_data and add option print/save controls to isospace plot_data 

### DIFF
--- a/R/load_discr_data.R
+++ b/R/load_discr_data.R
@@ -6,7 +6,7 @@
 #' then set TDF = 0 (ex. essential fatty acids, fatty acid profile data,
 #' element concentrations).
 #'
-#' @param filename csv file with the discrimination data
+#' @param filename csv file or dataframe with the discrimination data
 #' @param mix output from \code{\link{load_mix_data}}
 #'
 #' @return discr, a list including:
@@ -16,7 +16,7 @@
 #' }
 #' @export
 load_discr_data <- function(filename,mix){
-  DISCR <- read.csv(filename)
+  if(grepl(".*.csv", filename)[1]) DISCR <- read.csv(filename) else DISCR <- as.data.frame(filename) #allows for data.frame or .csv path input
   row.names(DISCR)<-DISCR[,1]     # store the row names of DISCR (sources)
   DISCR <- as.matrix(DISCR[-1])   # remove source names column of DISCR
   DISCR <- DISCR[order(rownames(DISCR)),]  # rearrange DISCR so sources are in alphabetical order

--- a/R/load_mix_data.R
+++ b/R/load_mix_data.R
@@ -3,7 +3,7 @@
 #' \code{load_mix_data} loads the mixture data file and names the biotracers and
 #' any Fixed, Random, or Continuous Effects.
 #'
-#' @param filename csv file with the mixture/consumer data
+#' @param filename csv file or dataframe with the mixture/consumer data
 #' @param iso_names vector of isotope column headings in 'filename'
 #' @param factors vector of random/fixed effect column headings in 'filename'.
 #'          NULL if no factors.
@@ -71,7 +71,7 @@
 #' select 1 or 0.
 #' @export
 load_mix_data <- function(filename,iso_names,factors,fac_random,fac_nested,cont_effects){
-  X <- read.csv(filename)         # raw consumer data
+  if(grepl(".*.csv", filename)[1]) X <- read.csv(filename) else X <- as.data.frame(filename) # raw consumer data as either .csv file path or data.frame
   n.iso <- length(iso_names)      # number of isotopes
   # if n.iso = 0, error
   if(n.iso == 0){

--- a/R/load_source_data.R
+++ b/R/load_source_data.R
@@ -12,7 +12,7 @@
 #'  \item Source SD = 0
 #' }
 #'
-#' @param filename character, csv file with the source data.
+#' @param filename character, csv file or dataframe with the source data.
 #' @param source_factors character, column heading in 'filename' that matches
 #'   a Fixed or Random Effect from the mixture data (\code{mix$factors}).
 #'   Only used if you have source data by a factor (e.g. "Region"), otherwise \code{NULL}.
@@ -58,7 +58,7 @@
 #' @export
 #'
 load_source_data <- function(filename,source_factors=NULL,conc_dep,data_type,mix){
-  SOURCE <- read.csv(filename)
+  if(grepl(".*.csv", filename)[1]) SOURCE <- read.csv(filename) else SOURCE <- as.data.frame(filename) #source df as either .csv path or data.frame
   source.fac <- length(source_factors)
   if(source.fac > 1){
     stop(paste("More than one source factor.

--- a/R/plot_data.R
+++ b/R/plot_data.R
@@ -34,7 +34,14 @@
 #'
 #' @seealso \code{\link{plot_data_two_iso}}, \code{\link{plot_data_one_iso}}
 #' @export
-plot_data <- function(filename,plot_save_pdf,plot_save_png,mix,source,discr, return_obj=FALSE){
+plot_data <- function(filename,
+                      plot_save_pdf=TRUE,
+                      plot_save_png=FALSE,
+                      mix,
+                      source,
+                      discr,
+                      return_obj=FALSE,
+                      show_plot=FALSE){
   # check that discr rownames match source_names
   if(!identical(rownames(discr$mu),source$source_names)){
     stop(paste("*** Error: Source names do not match in source and discr
@@ -43,30 +50,63 @@ plot_data <- function(filename,plot_save_pdf,plot_save_png,mix,source,discr, ret
     stop(paste("*** Error: Source names do not match in source and discr
     data files. Please check your source and discr data file row names.",sep=""))}
 
+  # initialize an empty list to store plot objects if return_obj=TRUE
+  plots <- list() 
+
+  # case 1: single tracer
   if(mix$n.iso==1){
-    plot_data_one_iso(mix,source,discr,filename,plot_save_pdf,plot_save_png,return_obj)
-    if(return_obj == TRUE) {
-      g = plot_data_one_iso(mix,source,discr,filename,plot_save_pdf,plot_save_png,return_obj=return_obj)
-    }
+
+    # create and save plot object 
+    ## return_obj = TRUE returns plot object, but does not print unless explicitly called
+    g <- plot_data_one_iso(
+      mix = mix, 
+      source = source, 
+      discr = discr,
+      filename = filename,
+      plot_save_pdf = plot_save_pdf,
+      plot_save_png = plot_save_png,
+      return_obj = TRUE
+    )
+
+    # optionally: display plot (show_plot = TRUE)
+    if (isTRUE(show_plot)) print(g)
+    
+    # optionally: store plot object 
+    if (isTRUE(return_obj)) plots[["iso1"]] <- g
+
+  # case 2: multiple tracers
   } else {
-    for(iso1 in 1:(mix$n.iso-1)){
-      for(iso2 in (iso1+1):mix$n.iso){
-        plot_data_two_iso(isotopes=c(iso1,iso2),mix=mix,source=source,
-          discr=discr,
-          filename=filename,
-          plot_save_pdf=plot_save_pdf,
-          plot_save_png=plot_save_png,return_obj=return_obj)
-        if(return_obj == TRUE) {
-          g = plot_data_two_iso(isotopes=c(iso1,iso2),mix=mix,source=source,
-            discr=discr,
-            filename=filename,
-            plot_save_pdf=plot_save_pdf,
-            plot_save_png=plot_save_png,return_obj=return_obj)
+
+    for (iso1 in 1:(mix$n.iso - 1)) {
+      for (iso2 in (iso1 + 1):mix$n.iso) {
+
+        # create and save plot object 
+        ## return_obj = TRUE returns plot object, but does not print unless explicitly called
+        g <- plot_data_two_iso(
+          isotopes = c(iso1, iso2),
+          mix = mix, source = source, discr = discr,
+          filename = filename,
+          plot_save_pdf = plot_save_pdf,
+          plot_save_png = plot_save_png,
+          return_obj = TRUE
+        )
+
+        # optionally: display plot (show_plot = TRUE)
+        ## not recommended if using .rmd files as can trigger "too many open devices" issues
+        if (isTRUE(show_plot)) print(g)
+        
+        # optionally: store plot object 
+        if (isTRUE(return_obj)) {
+          nm <- paste0(mix$iso_names[iso1], "_vs_", mix$iso_names[iso2])
+          plots[[nm]] <- g
         }
       }
     }
   }
-  if(return_obj == TRUE) {
-    return(g)
-  }
+
+  # return plot objects only if requested
+  if (isTRUE(return_obj)) return(plots)
+  
+  # suppress printing NULL when plot objects are saved but not returned
+  invisible(NULL)
 } # end plot_data function


### PR DESCRIPTION
### I made two related sets of modifications to improve usability when running many MixSIAR models programmatically.

**1. Allow data.frame input to load_mix_data(), load_source_data(), and load_discr_data()**

I lightly modified the load_[mix/source/discr]_data functions to accept data.frame objects in addition to file paths to .csv files.

_Reason: This allows users to format MixSIAR input data within R scripts, rather than writing multiple intermediate .csv files and reading those into the models. This is particularly helpful when running many models (e.g., multiple consumer species with species-specific informative priors–necessitating an individual model per species), where the current workflow would require generating dozens of separate .csv files (e.g., 10 species × mix/source/discrimination = 30 files). Accepting data.frame input makes large, scripted workflows more efficient and user-friendly._

**2. Add optional control over saving, printing, and returning isospace plots in plot_data()**

I modified plot_data() to optionally:

- save plots to file,
- print plots to the active graphics device, and/or
- return ggplot objects for modification.

_Reason: This provides users with more control over plotting behavior and helps prevent graphics device overload—particularly in R Markdown or batch workflows—when running multiple models or using many tracers. For example, models with six EAA tracers produce 15 pairwise isospace plots per model; when run in loops/across multiple species, this can easily trigger “too many open devices” errors. Separating plot saving from plot display improves stability without changing default behavior._